### PR TITLE
[Mod] directory level of output error images

### DIFF
--- a/nobunaga/image_printer.py
+++ b/nobunaga/image_printer.py
@@ -12,8 +12,7 @@ from tqdm import tqdm
 
 import nobunaga.constants as Const
 from nobunaga.evaluator import Evaluator
-from nobunaga.io import (plot_bar, plot_matrix, plot_pie, print_table,
-                         write_label)
+from nobunaga.io import plot_bar, plot_matrix, plot_pie, print_table, write_label
 
 
 class ImagePrinter(object):
@@ -71,7 +70,9 @@ class ImagePrinter(object):
         if normalize:
             confusion_matrix = confusion_matrix / confusion_matrix.astype(np.float).sum(axis=0)
         category_names = [category_name for category, category_name in self._categories.items()]
-        output_file_path = str(self._out_dir / f"{self._model_name}_class_error_confusion_matrix.png")
+        output_file_path = str(
+            self._out_dir / f"{self._model_name}_class_error_confusion_matrix.png"
+        )
         plot_matrix(
             confusion_matrix, category_names, category_names, "Pred", "Gt", output_file_path
         )
@@ -260,22 +261,20 @@ class ImagePrinter(object):
             for all_label in image.get_labels():
                 # pred label
                 all_pred_label = all_label.get_pred_label()
-                if all_pred_label is not None and all_pred_label.get_confidence() > self._evaluation.get_confidence_threshold():
-                    pred_category_name = self._categories.get(
-                        all_pred_label.get_category_id()
-                    )
+                if (
+                    all_pred_label is not None
+                    and all_pred_label.get_confidence()
+                    > self._evaluation.get_confidence_threshold()
+                ):
+                    pred_category_name = self._categories.get(all_pred_label.get_category_id())
                     pred_bbox = all_pred_label.get_bbox()
-                    pred_confidence = float(
-                        "{:.2f}".format(all_pred_label.get_confidence() * 100)
-                    )
+                    pred_confidence = float("{:.2f}".format(all_pred_label.get_confidence() * 100))
                     all_pred_bboxes.append([pred_category_name] + pred_bbox + [pred_confidence])
 
                 # gt label
                 all_gt_label = all_label.get_gt_match_label()
                 if all_gt_label is not None:
-                    gt_category_name = self._categories.get(
-                        all_gt_label.get_category_id()
-                    )
+                    gt_category_name = self._categories.get(all_gt_label.get_category_id())
                     gt_bbox = all_gt_label.get_bbox()
                     gt_confidence = ""
                     all_gt_bboxes.append([gt_category_name] + gt_bbox + [gt_confidence])
@@ -290,9 +289,17 @@ class ImagePrinter(object):
             # create output directory
             error_type = error_label.get_error_type()
             if error_type in [Const.ERROR_TYPE_CLASS, Const.ERROR_TYPE_BOTH]:
-                category_name = self._categories.get(error_label.get_gt_unmatch_label().get_category_id())
-            elif error_type in [Const.ERROR_TYPE_LOCATION, Const.ERROR_TYPE_MISS, Const.ERROR_TYPE_DUPLICATE]:
-                category_name = self._categories.get(error_label.get_gt_match_label().get_category_id())
+                category_name = self._categories.get(
+                    error_label.get_gt_unmatch_label().get_category_id()
+                )
+            elif error_type in [
+                Const.ERROR_TYPE_LOCATION,
+                Const.ERROR_TYPE_MISS,
+                Const.ERROR_TYPE_DUPLICATE,
+            ]:
+                category_name = self._categories.get(
+                    error_label.get_gt_match_label().get_category_id()
+                )
             else:
                 category_name = self._categories.get(error_label.get_pred_category_id())
 
@@ -303,9 +310,7 @@ class ImagePrinter(object):
                 output_dir
                 / f"{image_name_path.stem}_{str(index_dict.get(image_name, 1))}{image_name_path.suffix}"
             )
-            write_label(
-                str(self._image_dir / image_name), new_file_path, bboxes, 2
-            )
+            write_label(str(self._image_dir / image_name), new_file_path, bboxes, 2)
             index_dict[image_name] = index_dict.get(image_name, 1) + 1
 
     def output_error_summary(self):

--- a/nobunaga/image_printer.py
+++ b/nobunaga/image_printer.py
@@ -32,7 +32,7 @@ class ImagePrinter(object):
         for index, category_id in enumerate(self._categories.keys()):
             self._index_category_id_relations[category_id] = index
 
-        self._out_dir = Path("./_result")
+        self._out_dir = Path(f"./_{self._model_name}_result")
         self._out_dir.mkdir(exist_ok=True)
 
     def output_confusion_matrix(self, normalize: bool):
@@ -187,8 +187,6 @@ class ImagePrinter(object):
             plt.savefig(str(self._out_dir / f"{self._model_name}_error_type_strip.png"))
 
     def output_error_files(self, error_type: str):
-        output_dir = Path(f"./{self._model_name}_error")
-        output_dir.mkdir(exist_ok=True)
 
         # get all error labels
         error_labels = []
@@ -288,9 +286,22 @@ class ImagePrinter(object):
                 "all pred": all_pred_bboxes,
                 "all gt": all_gt_bboxes,
             }
+
+            # create output directory
+            error_type = error_label.get_error_type()
+            if error_type in [Const.ERROR_TYPE_CLASS, Const.ERROR_TYPE_BOTH]:
+                category_name = self._categories.get(error_label.get_gt_unmatch_label().get_category_id())
+            elif error_type in [Const.ERROR_TYPE_LOCATION, Const.ERROR_TYPE_MISS, Const.ERROR_TYPE_DUPLICATE]:
+                category_name = self._categories.get(error_label.get_gt_match_label().get_category_id())
+            else:
+                category_name = self._categories.get(error_label.get_pred_category_id())
+
+            output_dir = Path(f"./_{self._model_name}_error/{error_type}/{category_name}")
+            output_dir.mkdir(exist_ok=True, parents=True)
+
             new_file_path = str(
                 output_dir
-                / f"{image_name_path.stem}_{error_label.get_error_type()}_{str(index_dict.get(image_name, 1))}{image_name_path.suffix}"
+                / f"{image_name_path.stem}_{str(index_dict.get(image_name, 1))}{image_name_path.suffix}"
             )
             write_label(
                 str(self._image_dir / image_name), new_file_path, bboxes, 2


### PR DESCRIPTION
modify directory level of output error images to enable search what you want to see.
- first level: Error types
- second level: label names

enable rename output directory name of error images
- add name of argument m to directory prefix

Sorry for bother you when you have tough tasks.